### PR TITLE
Modification to allow linking with CPP projects when using flash_file.

### DIFF
--- a/pfs/dirent.h
+++ b/pfs/dirent.h
@@ -18,8 +18,16 @@ struct dirent {
     char           d_name[256]; /* Null-terminated filename */
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 DIR *opendir (const char *name);
 struct dirent *readdir (DIR *dirp);
 int closedir (DIR *dirp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pfs/pfs.h
+++ b/pfs/pfs.h
@@ -9,6 +9,10 @@ struct pfs_pfs;
 struct lfs_config;
 struct pfs_device;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Initialises the pico filesystem. In particular configures stdin,
 // stdout and stderr.
 
@@ -91,5 +95,9 @@ struct pfs_pfs *pfs_dev_fetch (void);
 // name is passed to the driver, which may use the string to
 // configure the device.
 int pfs_mknod (const char *name, int mode, const struct pfs_device *dev);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi!
First of all, thank you for share this awesome library!

I've found that link flash_filesystem library to a Cpp project using pico-sdk gives an linkage error. 

```
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: CMakeFiles/scriptPad.dir/filesManagement/filesManagement.cpp.obj: in function `filesManagement::initFileManagement()':
filesManagement.cpp:(.text._ZN15filesManagement18initFileManagementEv+0xe): undefined reference to `ffs_pico_createcfg(lfs_config*, int, int)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: filesManagement.cpp:(.text._ZN15filesManagement18initFileManagementEv+0x14): undefined reference to `pfs_ffs_create(lfs_config const*)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: filesManagement.cpp:(.text._ZN15filesManagement18initFileManagementEv+0x1c): undefined reference to `pfs_mount(pfs_pfs*, char const*)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: CMakeFiles/scriptPad.dir/filesManagement/filesManagement.cpp.obj: in function `filesManagement::listFiles(std::__cxx11::list<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*)':
filesManagement.cpp:(.text._ZN15filesManagement9listFilesEPNSt7__cxx114listINS0_12basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEE+0xe): undefined reference to `opendir(char const*)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: filesManagement.cpp:(.text._ZN15filesManagement9listFilesEPNSt7__cxx114listINS0_12basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEE+0x1c): undefined reference to `readdir(void*)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: filesManagement.cpp:(.text._ZN15filesManagement9listFilesEPNSt7__cxx114listINS0_12basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEE+0x68): undefined reference to `readdir(void*)'
/usr/lib/gcc/arm-none-eabi/10.3.1/../../../arm-none-eabi/bin/ld: filesManagement.cpp:(.text._ZN15filesManagement9listFilesEPNSt7__cxx114listINS0_12basic_stringIcSt11char_traitsIcESaIcEEESaIS6_EEE+0x72): undefined reference to `closedir(void*)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/scriptPad.dir/build.make:1527: scriptPad.elf] Error 1
make[1]: *** [CMakeFiles/Makefile2:1614: CMakeFiles/scriptPad.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

The solution that I've found it's to add this extern "C" to the affected headers.
