### PR TITLE
FIX: reference pointing to char and not char*

### DIFF
--- a/pfs/pfs_base.c
+++ b/pfs/pfs_base.c
@@ -35,7 +35,7 @@ static struct pfs_mount *mounts = NULL;
 static struct pfs_file ** files = NULL;
 static int num_handle = 0;
 static const char *cwd = NULL;
-static char rootdir = '/';
+static char *rootdir = "/";
 
 int pfs_error (int ierr)
     {
@@ -166,7 +166,7 @@ static struct pfs_mount *reference (const char **pn, const char **pr)
             {
             if ( (*pn)[m->nlen] == '\0' )
                 {
-                *pr = &rootdir;
+                *pr = rootdir;
                 return m;
                 }
             if ( (*pn)[m->nlen] == '/' )


### PR DESCRIPTION
I found that I wasn't able to use `stat` on `/dev` I would get error 6.

The issue is that the `rname` is being set the the address of a **char** however this needs to be a `char*` otherwise the logic used in `dev_stat` will read past the end of the `name` since the pointer is incremented and in this case `name` is only a single byte.

With this change I can now properly `stat` `/dev` and see it is a directory.